### PR TITLE
performace, two call to api

### DIFF
--- a/src/views/Tweets.vue
+++ b/src/views/Tweets.vue
@@ -123,7 +123,6 @@
       tableOptions: {
         handler () {
           this.getTweets()
-
         },
         deep: true
       }
@@ -144,9 +143,6 @@
             this.totalItems = res.data['hydra:totalItems']
           })
       }
-    },
-    mounted () {
-      this.$nextTick(() => this.getTweets())
     }
   }
 </script>


### PR DESCRIPTION
the watcher is triggering getTweets from api and the tick after mounted do it again